### PR TITLE
Update to azurerm 2.x and terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,61 @@
 # terraform-azure-yugabyte
 A Terraform module to deploy and run YugabyteDB on Microsoft Azure Cloud.
 
-## Config
-* First create a terraform file with provider details 
-  ```
-  provider "azurerm" 
-  { 
-    # Provide your Azure Creadentilals 
-    subscription_id = "AZURE_SUBSCRIPTION_ID"
-    client_id       = "AZURE_CLIENT_ID"
-    client_secret   = "AZURE_CLIENT_SECRET"
-    tenant_id       = "AZURE_TENANT_ID"
-  }
-  ```
-  Note :- To insatll terraform and configure it for Azure follow steps given [here](https://docs.microsoft.com/en-gb/azure/virtual-machines/linux/terraform-install-configure)
+## Configuration
+* To insatll terraform and configure it for Azure follow steps given [here](https://docs.microsoft.com/en-gb/azure/virtual-machines/linux/terraform-install-configure)
 
-* Now add the yugabyte terraform module to your file 
+* Export the required credentials in current shell
+  ```sh
+  echo "Setting environment variables for Terraform"
+  export ARM_SUBSCRIPTION_ID="your_subscription_id"
+  export ARM_CLIENT_ID="your_appId"
+  export ARM_CLIENT_SECRET="your_password"
+  export ARM_TENANT_ID="your_tenant_id"
   ```
+  <!-- The above code snippet is from
+  https://github.com/MicrosoftDocs/azure-docs/blob/eb381218252a33fb8b63e1163b6a39cd4b1835ef/articles/terraform/terraform-install-configure.md#configure-terraform-environment-variables
+  which is licensed under the MIT
+  license. https://github.com/MicrosoftDocs/azure-docs/blob/master/LICENSE-CODE
+  -->
+
+* Create a new directory along with a terraform file
+  ```sh
+  $ mkdir yugabytedb-deploy && cd yugabytedb-deploy
+  $ touch deploy.tf
+  ```
+* Open `deploy.tf` in your favorite editor and add following content to
+  it
+  ```hcl
   module "yugabyte-db-cluster" {
-  source = "github.com/YugaByte/terraform-azure-yugabyte.git"
+	source = "github.com/yugabyte/terraform-azure-yugabyte.git"
 
-  # The name of the cluster to be created.
-  cluster_name = "test-yugabyte"
+	# The name of the cluster to be created.
+	cluster_name = "test-yugabyte"
 
-  # key pair.
-  ssh_private_key = "SSH_PRIVATE_KEY_HERE"
-  ssh_public_key = "SSH_PUBLIC_KEY_HERE"
-  ssh_user = "SSH_USER_NAME_HERE"
+	# key pair.
+	ssh_private_key = "PATH_TO_SSH_PRIVATE_KEY_FILE"
+	ssh_public_key  = "PATH_TO_SSH_PUBLIC_KEY_FILE"
+	ssh_user        = "SSH_USER_NAME"
 
-  # The region name where the nodes should be spawned.
-  region_name = "YOUR VPC REGION"
+	# The region name where the nodes should be spawned.
+	region_name = "YOUR VPC REGION"
 
-  # The name of resource  group in which all Azure resource will be created. 
-  resource_group = "test-yugabyte"
+	# The name of resource  group in which all Azure resource will be created.
+	resource_group = "test-yugabyte"
 
-  # Replication factor.
-  replication_factor = "3"
+	# Replication factor.
+	replication_factor = "3"
 
-  # The number of nodes in the cluster, this cannot be lower than the replication factor.
-  node_count = "3"
+	# The number of nodes in the cluster, this cannot be lower than the replication factor.
+	node_count = "3"
   }
-  ```
 
+  output "ui" {
+	value = "${module.yugabyte-db-cluster.ui}"
+  }
+
+  # You can add other outputs from output.tf here
+  ```
 
 ## Usage
 
@@ -57,20 +71,19 @@ To check what changes are going to happen in the environment run the following
 $ terraform plan
 ```
 
-
 Now run the following to create the instances and bring up the cluster.
 
 ```
 $ terraform apply
 ```
 
-Once the cluster is created, you can go to the URL `http://<node ip or dns name>:7000` to view the UI. You can find the node's ip or dns by running the following:
+Once the cluster is created, you can go to the URL `http://<node ip or dns name>:7000` to view the UI. You can find the node's public IP by running the following:
 
 ```
-$ terraform state show azurerm_virtual_machine.YugaByte-Node[0]
+$ terraform state show module.yugabyte-db-cluster.azurerm_public_ip.YugaByte_Public_IP[0]
 ```
 
-You can access the cluster UI by going to any of the following URLs.
+You can access the cluster UI by going to public IP address of any of the instances at port `7000`. The IP address can be viewed by replacing `0` from above command with desired index.
 
 You can check the state of the nodes at any point by running the following command.
 
@@ -84,3 +97,42 @@ To destroy what we just created, you can run the following command.
 $ terraform destroy
 ```
 `Note:- To make any changes in the created cluster you will need the terraform state files. So don't delete state files of Terraform.`
+
+## Migrating from old versions
+### Changes in #6 (terraform 0.12.x and azurerm 2.x)
+In order to migrate to the latest revision of this module which uses terraform `0.12.x` and azurerm `2.x`,
+* Download [latest version](https://www.terraform.io/downloads.html) of terraform which is >= `0.12`
+* Remove the `provider "azurerm" {}` block from your terraform file and set the credentials by following the instructions [here](#configuration).
+* Pull the latest code of yugabyte-db-cluster module.
+  ```sh
+  $ terraform get -update
+  ```
+* Get the latets versions of the dependencies.
+  ```sh
+  $ terraform init
+  ```
+* Download the migration script in same directory as of your terraform files.
+  ```sh
+  $ curl -O -L https://raw.githubusercontent.com/yugabyte/terraform-azure-yugabyte/master/hack/azurerm_1.x_to_2.x.sh
+  $ chmod +x azurerm_1.x_to_2.x.sh
+  ```
+* Run the script as `./azurerm_1.x_to_2.x.sh <number of nodes>`
+  ```console
+  $ ./azurerm_1.x_to_2.x.sh 3
+  …
+  Importing 'module.yugabyte-db-cluster.azurerm_network_interface_security_group_association.YugaByte-NIC-SG-Association[2]'.
+  module.yugabyte-db-cluster.azurerm_network_interface_security_group_association.YugaByte-NIC-SG-Association[2]: Importing from ID "<networkInterfaceID>|<networkSecurityGroupId>"...
+  module.yugabyte-db-cluster.azurerm_network_interface_security_group_association.YugaByte-NIC-SG-Association[2]: Import prepared!
+	Prepared azurerm_network_interface_security_group_association for import
+  module.yugabyte-db-cluster.azurerm_network_interface_security_group_association.YugaByte-NIC-SG-Association[2]: Refreshing state... [id=<networkInterfaceID>|<networkSecurityGroupId>]
+
+  Import successful!
+
+  The resources that were imported are shown above. These resources are now in
+  your Terraform state and will henceforth be managed by Terraform.
+  ```
+* Run terraform apply to update the state correctly.
+  ```sh
+  $ terraform apply
+  ```
+

--- a/hack/azurerm_1.x_to_2.x.sh
+++ b/hack/azurerm_1.x_to_2.x.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# This script can be used to migrate from azurerm version 1.x to 2.x.
+# To check if you have 1.x, run the following command.
+#
+# $ terraform version
+# Terraform v0.11.14
+# + provider.azurerm v1.44.0
+# + provider.null v2.1.2
+#
+# Make sure you update to a terraform version which is >= 0.12.0
+#
+# Pull the latest code of yugabyte-db-cluster module.
+#
+# $ terraform get -update
+#
+# Get the latets versions of the dependencies
+#
+# $ terraform init
+#
+# Now put this script in same directory as of your terraform files,
+# and execute it
+#
+# ./azurerm_1.x_to_2.x.sh
+#
+# Run terraform apply to update the state correctly
+#
+# $ terraform apply
+
+node_count="${1:-3}"
+
+if [[ -z "$(which jq 2>/dev/null)" ]]; then
+  echo "jq: command not found. This script depends on jq." 1>&2
+  exit 1
+fi
+
+security_group_id="$(terraform show -json \
+  | jq -r '.values.root_module.child_modules[0].resources[]
+    | select(.address == "azurerm_network_security_group.YugaByte-SG")
+    | .values.id')"
+
+for ((index=0; index < $((node_count)); index++)); do
+  interface_id="$(terraform show -json \
+    | jq --arg index "${index}" -r \
+      '.values.root_module.child_modules[0].resources[]
+      | select(.address == "azurerm_network_interface.YugaByte-NIC" and .index == ($index|tonumber))
+      | .values.id')"
+  resoure_address="module.yugabyte-db-cluster.azurerm_network_interface_security_group_association.YugaByte-NIC-SG-Association[${index}]"
+  echo "Importing '${resoure_address}'."
+  terraform import \
+    "${resoure_address}" \
+    "${interface_id}|${security_group_id}"
+done

--- a/main.tf
+++ b/main.tf
@@ -1,207 +1,246 @@
-resource "azurerm_resource_group" "YugaByte-Group" {
-    name     = "${var.resource_group == "null" ? var.cluster_name : var.resource_group}"
-    location = "${var.region_name}"
-
-    tags = {
-        environment = "${var.prefix}${var.cluster_name}"
-    }   
+terraform {
+  required_version = ">= 0.12"
 }
+
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "YugaByte-Group" {
+  name     = var.resource_group == "null" ? var.cluster_name : var.resource_group
+  location = var.region_name
+
+  tags = {
+    environment = "${var.prefix}${var.cluster_name}"
+  }
+}
+
 # Create virtual network
 resource "azurerm_virtual_network" "YugaByte-Network" {
-    name                = "${var.prefix}${var.cluster_name}-VPC"
-    address_space       = ["10.0.0.0/16"]
-    location            = "${var.region_name}"
-    resource_group_name = "${azurerm_resource_group.YugaByte-Group.name}"
+  name                = "${var.prefix}${var.cluster_name}-VPC"
+  address_space       = ["10.0.0.0/16"]
+  location            = var.region_name
+  resource_group_name = azurerm_resource_group.YugaByte-Group.name
 
-    tags = {
-        environment = "${var.prefix}${var.cluster_name}"
-    }
+  tags = {
+    environment = "${var.prefix}${var.cluster_name}"
+  }
 }
 
 # Create subnet
 resource "azurerm_subnet" "YugaByte-SubNet" {
-    count                = "${var.subnet_count}"
-    name                 = "${var.prefix}${var.cluster_name}-Subnet-${format("%d", count.index + 1)}"
-    resource_group_name  = "${azurerm_resource_group.YugaByte-Group.name}"
-    virtual_network_name = "${azurerm_virtual_network.YugaByte-Network.name}"
-    address_prefix       = "10.0.${count.index+1}.0/24"
+  count                = var.subnet_count
+  name                 = "${var.prefix}${var.cluster_name}-Subnet-${format("%d", count.index + 1)}"
+  resource_group_name  = azurerm_resource_group.YugaByte-Group.name
+  virtual_network_name = azurerm_virtual_network.YugaByte-Network.name
+  address_prefix       = "10.0.${count.index + 1}.0/24"
 }
 
 # Create public IPs
 resource "azurerm_public_ip" "YugaByte_Public_IP" {
-    count                        = "${var.node_count}"
-    name                         = "${var.prefix}${var.cluster_name}-Public-IP-${format("%d", count.index)}"
-    location                     = "${var.region_name}"
-    resource_group_name          = "${azurerm_resource_group.YugaByte-Group.name}"
-    allocation_method            = "Static"
-    sku                          = "Standard"
-    zones                        = ["${element(var.zone_list, count.index)}"]
+  count               = var.node_count
+  name                = "${var.prefix}${var.cluster_name}-Public-IP-${format("%d", count.index)}"
+  location            = var.region_name
+  resource_group_name = azurerm_resource_group.YugaByte-Group.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  zones               = [element(var.zone_list, count.index)]
 
-    tags = {
-        environment = "${var.prefix}${var.cluster_name}"
-    }
+  tags = {
+    environment = "${var.prefix}${var.cluster_name}"
+  }
 }
 
 # Create Network Security Group and rule
 resource "azurerm_network_security_group" "YugaByte-SG" {
-    name                = "${var.prefix}${var.cluster_name}-SG"
-    location            = "${var.region_name}"
-    resource_group_name = "${azurerm_resource_group.YugaByte-Group.name}"
-    
-    security_rule {
-        name                       = "SSH"
-        priority                   = 1001
-        direction                  = "Inbound"
-        access                     = "Allow"
-        protocol                   = "Tcp"
-        source_port_range          = "*"
-        destination_port_ranges     = ["22","9000","7000","6379","9042","5433","7100", "9100"]
-        source_address_prefix      = "*"
-        destination_address_prefix = "*"
-    }
+  name                = "${var.prefix}${var.cluster_name}-SG"
+  location            = var.region_name
+  resource_group_name = azurerm_resource_group.YugaByte-Group.name
 
-    tags = {
-        environment = "${var.prefix}${var.cluster_name}"
-    }
+  security_rule {
+    name                       = "SSH"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_ranges    = ["22", "9000", "7000", "6379", "9042", "5433", "7100", "9100"]
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  tags = {
+    environment = "${var.prefix}${var.cluster_name}"
+  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "YugaByte-SG-Association" {
-    count                     = "${var.node_count}"
-    subnet_id                 = "${element(azurerm_subnet.YugaByte-SubNet.*.id, count.index)}"
-    network_security_group_id = "${azurerm_network_security_group.YugaByte-SG.id}"
+  count                     = var.node_count
+  subnet_id                 = element(azurerm_subnet.YugaByte-SubNet.*.id, count.index)
+  network_security_group_id = azurerm_network_security_group.YugaByte-SG.id
 }
 
 # Create network interface
 resource "azurerm_network_interface" "YugaByte-NIC" {
-    count                     = "${var.node_count}"
-    name                      = "${var.prefix}${var.cluster_name}-NIC-${format("%d", count.index + 1)}"
-    location                  = "${var.region_name}"
-    resource_group_name       = "${azurerm_resource_group.YugaByte-Group.name}"
-    network_security_group_id = "${azurerm_network_security_group.YugaByte-SG.id}"
+  count               = var.node_count
+  name                = "${var.prefix}${var.cluster_name}-NIC-${format("%d", count.index + 1)}"
+  location            = var.region_name
+  resource_group_name = azurerm_resource_group.YugaByte-Group.name
 
-    ip_configuration {
-        name                          = "${var.prefix}${var.cluster_name}-NicConfiguration"
-        subnet_id                     = "${element(azurerm_subnet.YugaByte-SubNet.*.id,count.index)}"
-        private_ip_address_allocation = "Dynamic"
-        public_ip_address_id          = "${element(azurerm_public_ip.YugaByte_Public_IP.*.id, count.index)}"
-    }
+  ip_configuration {
+    name                          = "${var.prefix}${var.cluster_name}-NicConfiguration"
+    subnet_id                     = element(azurerm_subnet.YugaByte-SubNet.*.id, count.index)
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = element(azurerm_public_ip.YugaByte_Public_IP.*.id, count.index)
+  }
 
-    tags = {
-        environment = "${var.prefix}${var.cluster_name}"
-    }
+  tags = {
+    environment = "${var.prefix}${var.cluster_name}"
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "YugaByte-NIC-SG-Association" {
+  count                     = var.node_count
+  network_interface_id      = element(azurerm_network_interface.YugaByte-NIC.*.id, count.index)
+  network_security_group_id = azurerm_network_security_group.YugaByte-SG.id
 }
 
 # Create virtual machine
 resource "azurerm_virtual_machine" "YugaByte-Node" {
-    count                 = "${var.node_count}"
-    name                  = "${var.prefix}${var.cluster_name}-node-${format("%d", count.index + 1)}"
-    location              = "${var.region_name}"
-    resource_group_name   = "${azurerm_resource_group.YugaByte-Group.name}"
-    network_interface_ids = ["${element(azurerm_network_interface.YugaByte-NIC.*.id, count.index)}"]
-    vm_size               = "${var.vm-size}"
-    zones                 = ["${element(var.zone_list, count.index)}"]
+  count                 = var.node_count
+  name                  = "${var.prefix}${var.cluster_name}-node-${format("%d", count.index + 1)}"
+  location              = var.region_name
+  resource_group_name   = azurerm_resource_group.YugaByte-Group.name
+  network_interface_ids = [element(azurerm_network_interface.YugaByte-NIC.*.id, count.index)]
+  vm_size               = var.vm-size
+  zones                 = [element(var.zone_list, count.index)]
 
-    storage_os_disk {
-        name              = "${var.prefix}${var.cluster_name}-disk-n${format("%d", count.index + 1)}"
-        caching           = "ReadWrite"
-        create_option     = "FromImage"
-        managed_disk_type = "Premium_LRS"
-        disk_size_gb      = "${var.disk_size}"
-    }
+  storage_os_disk {
+    name              = "${var.prefix}${var.cluster_name}-disk-n${format("%d", count.index + 1)}"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Premium_LRS"
+    disk_size_gb      = var.disk_size
+  }
 
-    storage_image_reference {
+  storage_image_reference {
+    publisher = "OpenLogic"
+    offer     = "CentOS"
+    sku       = "7.5"
+    version   = "latest"
+  }
 
-        publisher = "OpenLogic"
-        offer     = "CentOS"
-        sku       = "7.5"
-        version   = "latest"
-    }
+  os_profile {
+    computer_name  = "${var.prefix}${var.cluster_name}${format("%d", count.index + 1)}"
+    admin_username = var.ssh_user
+  }
 
-    os_profile {
-        computer_name  = "${var.prefix}${var.cluster_name}${format("%d", count.index + 1)}"
-        admin_username = "${var.ssh_user}"
+  os_profile_linux_config {
+    disable_password_authentication = true
+    ssh_keys {
+      path     = "/home/${var.ssh_user}/.ssh/authorized_keys"
+      key_data = file(var.ssh_public_key)
     }
+  }
 
-    os_profile_linux_config {
-        disable_password_authentication = true
-        ssh_keys {
-            path     = "/home/${var.ssh_user}/.ssh/authorized_keys"
-            key_data = "${file(var.ssh_public_key)}"
-        }
-    }
+  tags = {
+    environment = "${var.prefix}${var.cluster_name}"
+  }
 
-    tags = {
-        environment = "${var.prefix}${var.cluster_name}"
+  provisioner "file" {
+    source      = "${path.module}/utilities/scripts/install_software.sh"
+    destination = "/home/${var.ssh_user}/install_software.sh"
+    connection {
+      type = "ssh"
+      user = var.ssh_user
+      host = element(
+        azurerm_public_ip.YugaByte_Public_IP.*.ip_address,
+        count.index,
+      )
+      private_key = file(var.ssh_private_key)
     }
-     provisioner "file" {
-        source = "${path.module}/utilities/scripts/install_software.sh"
-        destination = "/home/${var.ssh_user}/install_software.sh"
-        connection {
-            type = "ssh"
-            user = "${var.ssh_user}"
-            host = "${element(azurerm_public_ip.YugaByte_Public_IP.*.ip_address, count.index)}"
-            private_key = "${file(var.ssh_private_key)}"
-        }
-    }
+  }
 
-    provisioner "file" {
-        source = "${path.module}/utilities/scripts/create_universe.sh"
-        destination ="/home/${var.ssh_user}/create_universe.sh"
-        connection {
-            type = "ssh"
-            user = "${var.ssh_user}"
-            host = "${element(azurerm_public_ip.YugaByte_Public_IP.*.ip_address, count.index)}"
-            private_key = "${file(var.ssh_private_key)}"
-        }
+  provisioner "file" {
+    source      = "${path.module}/utilities/scripts/create_universe.sh"
+    destination = "/home/${var.ssh_user}/create_universe.sh"
+    connection {
+      type = "ssh"
+      user = var.ssh_user
+      host = element(
+        azurerm_public_ip.YugaByte_Public_IP.*.ip_address,
+        count.index,
+      )
+      private_key = file(var.ssh_private_key)
     }
-    provisioner "file" {
-        source = "${path.module}/utilities/scripts/start_master.sh"
-        destination ="/home/${var.ssh_user}/start_master.sh"
-        connection {
-            type = "ssh"
-            user = "${var.ssh_user}"
-            host = "${element(azurerm_public_ip.YugaByte_Public_IP.*.ip_address, count.index)}"
-            private_key = "${file(var.ssh_private_key)}"
-        }
-    }
-    provisioner "file" {
-        source = "${path.module}/utilities/scripts/start_tserver.sh"
-        destination ="/home/${var.ssh_user}/start_tserver.sh"
-        connection {
-            type = "ssh"
-            user = "${var.ssh_user}"
-            host = "${element(azurerm_public_ip.YugaByte_Public_IP.*.ip_address, count.index)}"
-            private_key = "${file(var.ssh_private_key)}"
-        }
-    }
-     provisioner "remote-exec" {
-        inline = [
-            "chmod +x /home/${var.ssh_user}/install_software.sh",
-            "chmod +x /home/${var.ssh_user}/create_universe.sh",
-            "chmod +x /home/${var.ssh_user}/start_tserver.sh",
-            "chmod +x /home/${var.ssh_user}/start_master.sh",
-            "/home/${var.ssh_user}/install_software.sh '${var.yb_version}' '${var.yb_download_url}'"
-        ]
-        connection {
-            type = "ssh"
-            user = "${var.ssh_user}"
-            host = "${element(azurerm_public_ip.YugaByte_Public_IP.*.ip_address, count.index)}"
-            private_key = "${file(var.ssh_private_key)}"
-        }
-    }
-}
-locals {
-    depends_on = ["azurerm_virtual_machine.YugaByte-Node"]
-    ssh_ip_list = "${var.use_public_ip_for_ssh == "true" ? join(" ",azurerm_public_ip.YugaByte_Public_IP.*.ip_address) : join(" ",azurerm_network_interface.YugaByte-NIC.*.private_ip_address)}"
-    config_ip_list = "${join(" ",azurerm_network_interface.YugaByte-NIC.*.private_ip_address)}"
-    zone = "${join(" ",azurerm_virtual_machine.YugaByte-Node.*.zones.0)}"
-}
+  }
 
-resource "null_resource" "create_yugabyte_universe" {
-  depends_on = ["azurerm_virtual_machine.YugaByte-Node"]
+  provisioner "file" {
+    source      = "${path.module}/utilities/scripts/start_master.sh"
+    destination = "/home/${var.ssh_user}/start_master.sh"
+    connection {
+      type = "ssh"
+      user = var.ssh_user
+      host = element(
+        azurerm_public_ip.YugaByte_Public_IP.*.ip_address,
+        count.index,
+      )
+      private_key = file(var.ssh_private_key)
+    }
+  }
 
-  provisioner "local-exec" {
-      command = "${path.module}/utilities/scripts/create_universe.sh 'Azure' '${var.region_name}' ${var.replication_factor} '${local.config_ip_list}' '${local.ssh_ip_list}' '${local.zone}' '${var.ssh_user}' ${var.ssh_private_key}"
+  provisioner "file" {
+    source      = "${path.module}/utilities/scripts/start_tserver.sh"
+    destination = "/home/${var.ssh_user}/start_tserver.sh"
+    connection {
+      type = "ssh"
+      user = var.ssh_user
+      host = element(
+        azurerm_public_ip.YugaByte_Public_IP.*.ip_address,
+        count.index,
+      )
+      private_key = file(var.ssh_private_key)
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/${var.ssh_user}/install_software.sh",
+      "chmod +x /home/${var.ssh_user}/create_universe.sh",
+      "chmod +x /home/${var.ssh_user}/start_tserver.sh",
+      "chmod +x /home/${var.ssh_user}/start_master.sh",
+      "/home/${var.ssh_user}/install_software.sh '${var.yb_version}'",
+    ]
+    connection {
+      type = "ssh"
+      user = var.ssh_user
+      host = element(
+        azurerm_public_ip.YugaByte_Public_IP.*.ip_address,
+        count.index,
+      )
+      private_key = file(var.ssh_private_key)
+    }
   }
 }
 
+locals {
+  depends_on = [azurerm_virtual_machine.YugaByte-Node]
+  ssh_ip_list = var.use_public_ip_for_ssh == "true" ? join(" ", azurerm_public_ip.YugaByte_Public_IP.*.ip_address) : join(
+    " ",
+    azurerm_network_interface.YugaByte-NIC.*.private_ip_address,
+  )
+  config_ip_list = join(
+    " ",
+    azurerm_network_interface.YugaByte-NIC.*.private_ip_address,
+  )
+  zone = join(" ", azurerm_virtual_machine.YugaByte-Node.*.zones.0)
+}
+
+resource "null_resource" "create_yugabyte_universe" {
+  depends_on = [azurerm_virtual_machine.YugaByte-Node]
+
+  provisioner "local-exec" {
+    command = "${path.module}/utilities/scripts/create_universe.sh 'Azure' '${var.region_name}' ${var.replication_factor} '${local.config_ip_list}' '${local.ssh_ip_list}' '${local.zone}' '${var.ssh_user}' ${var.ssh_private_key}"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,32 +1,34 @@
 output "ui" {
   sensitive = false
-  value     = "http://${azurerm_public_ip.YugaByte_Public_IP.0.ip_address}:7000"
+  value     = "http://${azurerm_public_ip.YugaByte_Public_IP[0].ip_address}:7000"
 }
+
 output "ssh_user" {
   sensitive = false
-  value = "${var.ssh_user}"
+  value     = var.ssh_user
 }
+
 output "ssh_key" {
   sensitive = false
-  value     = "${var.ssh_private_key}"
+  value     = var.ssh_private_key
 }
 
 output "JDBC" {
-  sensitive =false
-  value     = "postgresql://postgres@${azurerm_public_ip.YugaByte_Public_IP.0.ip_address}:5433"
+  sensitive = false
+  value     = "postgresql://postgres@${azurerm_public_ip.YugaByte_Public_IP[0].ip_address}:5433"
 }
 
-output "YSQL"{
+output "YSQL" {
   sensitive = false
-  value     = "psql -U postgres -h ${azurerm_public_ip.YugaByte_Public_IP.0.ip_address} -p 5433"
+  value     = "psql -U postgres -h ${azurerm_public_ip.YugaByte_Public_IP[0].ip_address} -p 5433"
 }
 
-output "YCQL"{
+output "YCQL" {
   sensitive = false
-  value     = "cqlsh ${azurerm_public_ip.YugaByte_Public_IP.0.ip_address} 9042"
+  value     = "cqlsh ${azurerm_public_ip.YugaByte_Public_IP[0].ip_address} 9042"
 }
 
-output "YEDIS"{
+output "YEDIS" {
   sensitive = false
-  value     = "redis-cli -h ${azurerm_public_ip.YugaByte_Public_IP.0.ip_address} -p 6379"
- }
+  value     = "redis-cli -h ${azurerm_public_ip.YugaByte_Public_IP[0].ip_address} -p 6379"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,88 +1,97 @@
 variable "cluster_name" {
   description = "The name for the cluster (universe) being created."
-  type        = "string"
+  type        = string
 }
+
 variable "use_public_ip_for_ssh" {
   description = "Flag to control use of public or private ips for ssh."
-  default = "true"
-  type = "string"
+  default     = "true"
+  type        = string
 }
+
 variable "replication_factor" {
   description = "The replication factor for the universe."
   default     = 3
-  type        = "string"
+  type        = string
 }
+
 variable "node_count" {
   description = "The number of nodes to create YugaByte Db Cluter"
   default     = 3
-  type        = "string"  
+  type        = string
 }
+
 variable "ssh_private_key" {
   description = "The private key to use when connecting to the instances."
-  type        = "string"
+  type        = string
 }
+
 variable "ssh_public_key" {
   description = "SSH public key to be use when creating the instances."
-  type        = "string"
+  type        = string
 }
+
 variable "ssh_user" {
   description = "User name to ssh YugaByte Node to configure cluster"
-  type        = "string"
+  type        = string
 }
+
 variable "vm-size" {
   description = "Type of Node to be used for YugaByte DB node "
   default     = "Standard_DS1_v2"
-  type        = "string"
+  type        = string
 }
+
 variable "yb_edition" {
   description = "The edition of YugaByteDB to install"
   default     = "ce"
-  type        = "string"
+  type        = string
 }
 
 variable "yb_download_url" {
   description = "The download location of the YugaByteDB edition"
   default     = "https://downloads.yugabyte.com"
-  type        = "string"
+  type        = string
 }
 
 variable "yb_version" {
   description = "The version number of YugaByteDB to install"
   default     = "2.1.6.0"
-  type        = "string"
+  type        = string
 }
 
 variable "region_name" {
   description = "Region name for Azure"
   default     = "eastus"
-  type        = "string"
+  type        = string
 }
+
 variable "disk_size" {
   description = "Disk size for YugaByte DB nodes"
   default     = "50"
-  type        = "string"
+  type        = string
 }
+
 variable "prefix" {
   description = "Prefix prepended to all resources created."
   default     = "yugabyte-"
-  type        = "string"
+  type        = string
 }
+
 variable "resource_group" {
   description = "Resource group name for Azure"
   default     = "null"
-  type        = "string"
+  type        = string
 }
+
 variable "subnet_count" {
   description = "Number of sunbnet to be created"
   default     = 3
-  type        = "string"
+  type        = string
 }
 
 variable "zone_list" {
   description = "avability zone list"
-  default = ["1","2","3"]
-  type    = "list"
+  default     = ["1", "2", "3"]
+  type        = list(string)
 }
-
-
-


### PR DESCRIPTION
- Add provider block to main.tf
- Set required_version of terraform to >= 0.12
- Add script to migrate from older versions of module
- Update README.md with instructions for migration
- Apply terraform fmt on all the files

### Scenarios tested
- Creating new stack with terraform `v0.12.24`
- Creating a stack with terraform `v0.11.14` and azurerm `1.44` with code from master.
  - Added following block to my deploy.tf file to use old version of azurerm
    ```hcl
    provider "azurerm" {
      version = "~>1.0"
    }
    ```
- Upgrading to terrafrom `v0.12.24`, switching to code from this branch and following the instruction for migration.
