### PR TITLE
Update the utilities submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ A Terraform module to deploy and run YugabyteDB on Microsoft Azure Cloud.
   it
   ```hcl
   module "yugabyte-db-cluster" {
+    # The source module used for creating clusters on Azure.
 	source = "github.com/yugabyte/terraform-azure-yugabyte.git"
 
-	# The name of the cluster to be created.
+    # The name of the cluster to be created, change as per need.
 	cluster_name = "test-yugabyte"
 
 	# key pair.
@@ -50,16 +51,14 @@ A Terraform module to deploy and run YugabyteDB on Microsoft Azure Cloud.
 	node_count = "3"
   }
 
-  output "ui" {
-	value = "${module.yugabyte-db-cluster.ui}"
+  output "outputs" {
+	value = module.yugabyte-db-cluster
   }
-
-  # You can add other outputs from output.tf here
   ```
 
 ## Usage
 
-Init terraform first if you have not already done so.
+Initialize terraform first, if you have not already done so.
 
 ```
 $ terraform init
@@ -77,7 +76,7 @@ Now run the following to create the instances and bring up the cluster.
 $ terraform apply
 ```
 
-Once the cluster is created, you can go to the URL `http://<node ip or dns name>:7000` to view the UI. You can find the node's public IP by running the following:
+Once the cluster is created, you can go to the URL `http://<node ip or dns name>:7000` to view the UI. You can find the node's public IP address by running the following:
 
 ```
 $ terraform state show module.yugabyte-db-cluster.azurerm_public_ip.YugaByte_Public_IP[0]

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,7 @@ resource "azurerm_virtual_machine" "YugaByte-Node" {
   network_interface_ids = [element(azurerm_network_interface.YugaByte-NIC.*.id, count.index)]
   vm_size               = var.vm-size
   zones                 = [element(var.zone_list, count.index)]
+  depends_on            = [azurerm_network_interface_security_group_association.YugaByte-NIC-SG-Association]
 
   storage_os_disk {
     name              = "${var.prefix}${var.cluster_name}-disk-n${format("%d", count.index + 1)}"

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "azurerm_network_security_group" "YugaByte-SG" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "YugaByte-SG-Association" {
-  count                     = var.node_count
+  count                     = var.subnet_count
   subnet_id                 = element(azurerm_subnet.YugaByte-SubNet.*.id, count.index)
   network_security_group_id = azurerm_network_security_group.YugaByte-SG.id
 }


### PR DESCRIPTION
- Adding dependency on NIC-SG-Association in YugaByte-Node
  - If the dependency is missing then the destroy operation fails with error similar to this one, terraform-providers/terraform-provider-azurerm#6669
- Update the utilities submodule
- Fix wrong count on YugaByte-SG-Association resource
  - The count of association resource should be equal to the number of Subnet resources we create. Number of Subnets are equal to the number of zone available.
- Sync the README.md with docs.yugabyte.com

Fixes https://github.com/yugabyte/yugabyte-db/issues/4451
### Scenarios tested
- Tried creating a cluster with RF = 3 and node count = 6
- Cluster works as expected and the placement_info doesn't have any duplicate entries
```hcl
version: 1
replication_info {
  live_replicas {
    num_replicas: 4
    placement_blocks {
      cloud_info {
        placement_cloud: "Azure"
        placement_region: "eastus"
        placement_zone: "1"
      }
      min_num_replicas: 1
    }
    placement_blocks {
      cloud_info {
        placement_cloud: "Azure"
        placement_region: "eastus"
        placement_zone: "2"
      }
      min_num_replicas: 1
    }
    placement_blocks {
      cloud_info {
        placement_cloud: "Azure"
        placement_region: "eastus"
        placement_zone: "3"
      }
      min_num_replicas: 1
    }
  }
}
```
- `terraform destroy` works as expected.